### PR TITLE
custom item renderer now uses the mutable index component

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,6 @@
 
         },
         "ghcr.io/devcontainers/features/powershell:1": {
-            "version": "7.4.2"
         }
     },
     "overrideFeatureInstallOrder": [

--- a/commands.ps1
+++ b/commands.ps1
@@ -3,8 +3,8 @@ param([string]$type, [string]$Configuration = "Release")
 $ErrorActionPreferenceOld = $ErrorActionPreference;
 $ErrorActionPreference = "Stop";
 
-$DeployPath = $type -eq "build-dev" ? "vortex_devel/plugins" : "vortex/plugins"
-$type = $type -eq "build-dev" ? "build" : $type;
+$DeployPath = if ($type -eq "build-dev") {"vortex_devel/plugins"} else {"vortex/plugins"}
+$type = if ($type -eq "build-dev") {"build"} else {$type}
 
 try {
     # Clean

--- a/src/collections/legacyData.ts
+++ b/src/collections/legacyData.ts
@@ -37,7 +37,7 @@ const parseLegacyLoadOrder = async (
   const allModules = launcherManager.getAllModules();
 
   const suggestedLoadOrderEntries = Object.entries(collection.loadOrder);
-  const suggestedLoadOrder = suggestedLoadOrderEntries.reduce<PersistenceLoadOrderStorage>((arr, [id, entry], idx) => {
+  const suggestedLoadOrder = suggestedLoadOrderEntries.reduce<PersistenceLoadOrderStorage>((arr, [id, entry]) => {
     if (!allModules[id] && !state.persistent.mods[GAME_ID]?.[id]) {
       return arr;
     }
@@ -50,8 +50,6 @@ const parseLegacyLoadOrder = async (
           id: modId,
           name: entry.name ?? id,
           isSelected: entry.enabled,
-          isDisabled: entry.locked !== undefined && (entry.locked === `true` || entry.locked === `always`),
-          index: idx,
         });
       }
     });

--- a/src/game.ts
+++ b/src/game.ts
@@ -10,6 +10,7 @@ export class BannerlordGame implements types.IGame {
 
   public id: string = GAME_ID;
   public name = `Mount & Blade II: Bannerlord (BUTR)`;
+  public shortName = `M&B II: Bannerlord`;
   public logo = `gameart.jpg`;
   public mergeMods = true;
   public queryArgs: { [storeId: string]: types.IStoreQuery[] } = {

--- a/src/launcher/manager.ts
+++ b/src/launcher/manager.ts
@@ -406,7 +406,6 @@ Warning! This can lead to issues!`,
 
     const savedLoadOrder = persistenceToVortex(this.api, allModules, readLoadOrder(this.api));
 
-    let index = savedLoadOrder.length;
     for (const module of Object.values(allModules)) {
       if (!savedLoadOrder.find((x) => x.id === module.id)) {
         const mod = mods.find((x) => x.attributes?.subModsIds?.includes(module.id));
@@ -417,7 +416,6 @@ Warning! This can lead to issues!`,
           data: {
             moduleInfoExtended: module,
             hasSteamBinariesOnXbox: mod?.attributes?.steamBinariesOnXbox ?? false,
-            index: index++,
           },
         });
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,8 +37,6 @@ export interface IPersistenceLoadOrderEntry {
   id: string;
   name: string;
   isSelected: boolean;
-  isDisabled: boolean;
-  index: number;
 }
 
 export type VortexLoadOrderStorage = VortexLoadOrderEntry[];
@@ -46,7 +44,6 @@ export type VortexLoadOrderEntry = types.ILoadOrderEntry<IVortexViewModelData>;
 export interface IVortexViewModelData {
   moduleInfoExtended: vetypes.ModuleInfoExtendedWithMetadata;
   hasSteamBinariesOnXbox: boolean;
-  index: number;
 }
 
 export interface IModuleCache {

--- a/src/views/CollectionGeneralData/components/LoadOrderEntry.tsx
+++ b/src/views/CollectionGeneralData/components/LoadOrderEntry.tsx
@@ -18,7 +18,12 @@ export const LoadOrderEntry = (props: LoadOrderEntryProps): JSX.Element | null =
     return null;
   }
 
-  const loEntry = loadOrder.find((x) => x.id === entry.id);
+  const loIdx = loadOrder.findIndex((x) => x.id === entry.id);
+  if (loIdx === -1) {
+    return null;
+  }
+
+  const loEntry = loadOrder[loIdx];
   if (!loEntry || !loEntry.data) {
     return null;
   }
@@ -35,7 +40,7 @@ export const LoadOrderEntry = (props: LoadOrderEntryProps): JSX.Element | null =
 
   return (
     <ListGroupItem key={key} className={classes.join(' ')}>
-      <p className="load-order-index">{entry.index + 1}</p>
+      <p className="load-order-index">{loIdx + 1}</p>
       <ModuleIcon data={loEntry.data} />
       <p className="load-order-name">
         {name} ({version})

--- a/src/views/CollectionModOptionsData/components/LoadOrderEntry.tsx
+++ b/src/views/CollectionModOptionsData/components/LoadOrderEntry.tsx
@@ -18,7 +18,12 @@ export const LoadOrderEntry = (props: LoadOrderEntryProps): JSX.Element | null =
     return null;
   }
 
-  const loEntry = loadOrder.find((x) => x.id === entry.id);
+  const loIdx = loadOrder.findIndex((x) => x.id === entry.id);
+  if (loIdx === -1) {
+    return null;
+  }
+
+  const loEntry = loadOrder[loIdx];
   if (!loEntry || !loEntry.data) {
     return null;
   }
@@ -35,7 +40,7 @@ export const LoadOrderEntry = (props: LoadOrderEntryProps): JSX.Element | null =
 
   return (
     <ListGroupItem key={key} className={classes.join(' ')}>
-      <p className="load-order-index">{entry.index + 1}</p>
+      <p className="load-order-index">{loIdx + 1}</p>
       <ModuleIcon data={loEntry.data} />
       <p className="load-order-name">
         {name} ({version})

--- a/src/views/LoadOrder/components/LoadOrderItemRenderer.tsx
+++ b/src/views/LoadOrder/components/LoadOrderItemRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { BaseSyntheticEvent, useCallback, useContext } from 'react';
+import React, { BaseSyntheticEvent, useCallback, useContext, useMemo } from 'react';
 import { Checkbox, ListGroupItem } from 'react-bootstrap';
 import { useSelector, useStore } from 'react-redux';
 import { Icon, LoadOrderIndexInput, MainContext, selectors, types } from 'vortex-api';
@@ -8,7 +8,7 @@ import { ExternalBanner } from './ExternalBanner';
 import { ModuleDuplicates } from './ModuleDuplicates';
 import { ModuleProviderIcon } from './ModuleProviderIcon';
 import { SteamBinariesOnXbox } from './SteamBinariesOnXbox';
-import { IVortexViewModelData, VortexLoadOrderStorage } from '../../../types';
+import { VortexLoadOrderStorage } from '../../../types';
 import { CompatibilityInfo, ModuleIcon } from '../../Shared';
 import { isExternal, isLocked } from '../utils';
 import { IModuleCompatibilityInfo } from '../../../butr';
@@ -37,11 +37,8 @@ export const LoadOrderItemRenderer = (props: LoadOrderItemRendererProps): JSX.El
   const version = item.loEntry.data?.moduleInfoExtended.version
     ? versionToString(item.loEntry.data.moduleInfoExtended.version)
     : 'ERROR';
+  const position = loadOrder.findIndex((loEntry) => loEntry.id === item.loEntry.id) + 1;
 
-  const position =
-    loadOrder.findIndex((entry: types.IFBLOLoadOrderEntry<IVortexViewModelData>) => entry.id === item.loEntry.id) + 1;
-
-  const context = useContext(MainContext)
   let classes = ['load-order-entry'];
   if (className !== undefined) {
     classes = classes.concat(className.split(' '));
@@ -51,19 +48,42 @@ export const LoadOrderItemRenderer = (props: LoadOrderItemRendererProps): JSX.El
     classes = classes.concat('external');
   }
 
+  const context = useContext(MainContext);
   const store = useStore();
 
   const onStatusChange = useCallback(
     (evt: BaseSyntheticEvent<Event, HTMLInputElement & Checkbox, HTMLInputElement>) => {
-      const entry = {
+      if (!profile) {
+        return;
+      }
+
+      const loEntry = {
         ...item.loEntry,
         enabled: evt.target.checked,
       };
-      if (profile) {
-        store.dispatch(actionsLoadOrder.setFBLoadOrderEntry(profile.id, entry));
-      }
+      store.dispatch(actionsLoadOrder.setFBLoadOrderEntry(profile.id, loEntry));
     },
     [store, item, profile]
+  );
+
+  const lockedEntriesCount = useMemo(() => (loadOrder ?? []).filter((entry) => isLocked(entry)).length, [loadOrder]);
+
+  const onApplyIndex = useCallback(
+    (idx: number) => {
+      if (!profile) {
+        return;
+      }
+
+      const currentIdx = position;
+      if (currentIdx === idx) {
+        return;
+      }
+
+      const newLO = loadOrder.filter((entry) => entry.id !== item.loEntry.id);
+      newLO.splice(idx - 1, 0, item.loEntry);
+      store.dispatch(actionsLoadOrder.setFBLoadOrder(profile.id, newLO));
+    },
+    [store, item, profile, loadOrder, position]
   );
 
   const CheckBox = (): JSX.Element | null =>
@@ -79,35 +99,11 @@ export const LoadOrderItemRenderer = (props: LoadOrderItemRendererProps): JSX.El
   const Lock = (): JSX.Element | null =>
     isLocked(item.loEntry) ? <Icon className="locked-entry-logo" name="locked" /> : null;
 
-  const lockedEntriesCount = React.useMemo(() => {
-    return (loadOrder ?? []).filter((entry) => isLocked(entry)).length;
-  }, [loadOrder]);
-
-  const onApplyIndex = React.useCallback((idx: number) => {
-    if (!profile?.id) {
-      return;
-    }
-    const { item } = props;
-    const currentIdx = position;
-    if (currentIdx === idx) {
-      return;
-    }
-
-    const entry = {
-      ...item.loEntry,
-      index: idx,
-    };
-
-    const newLO = loadOrder.filter((entry) => entry.id !== item.loEntry.id);
-    newLO.splice(idx - 1, 0, entry);
-    store.dispatch(actionsLoadOrder.setFBLoadOrder(profile.id, newLO));
-  }, [profile, item]);
-
   return (
     <ListGroupItem key={key} className={classes.join(' ')} ref={props.item.setRef}>
       <Icon className="drag-handle-icon" name="drag-handle" />
       <LoadOrderIndexInput
-        className='load-order-index'
+        className="load-order-index"
         api={context.api}
         currentPosition={position}
         item={item.loEntry}


### PR DESCRIPTION
Hey @Aragas - just wanted to showcase how to use the new mutable index component that will be added in Vortex 1.13 (among other enhancements to FBLO)

Feel free to modify the code in any way (or ignore it completely) - will provide you with a preview version of Vortex 1.13 soon

- This will only work with Vortex 1.13 which includes multiple FBLO API enhancements such as multi-selection and mutable index (will be released as beta this week)